### PR TITLE
Fix parsing and Add filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The **issues** command is the wrapper for part of the [Issues resource](http://w
 
 #### List issues
 
-    $ redminerb issues [list] [--closed|-c] [--project_id|-p <id>] [--assigned_to_id|-a <id>]
+    $ redminerb issues [list] [--closed|-c] [--project_id|-p <id>] [--assigned_to_id|-a <id>] [--fixed_version_id|-v <id>]
 
 Examples:
 

--- a/lib/redminerb/cli/issues.rb
+++ b/lib/redminerb/cli/issues.rb
@@ -10,11 +10,12 @@ module Redminerb
       # rubocop:disable Metrics/AbcSize
       # (disabled to let the "closed" option be managed here)
       desc 'list', 'Shows open issues in our Redmine'
-      option :offset,         aliases: :o
-      option :limit,          aliases: :l
-      option :closed,         aliases: :c, type: :boolean
-      option :assigned_to_id, aliases: :a
-      option :project_id,     aliases: :p
+      option :offset,           aliases: :o
+      option :limit,            aliases: :l
+      option :closed,           aliases: :c, type: :boolean
+      option :assigned_to_id,   aliases: :a
+      option :project_id,       aliases: :p
+      option :fixed_version_id, aliases: :v
       def list(issue_id = nil)
         if issue_id
           show(issue_id)

--- a/lib/redminerb/client.rb
+++ b/lib/redminerb/client.rb
@@ -39,10 +39,10 @@ module Redminerb
     def get_json(path, params = {})
       Redminerb.init_required!
       res = _get(path, params)
-      if res.status == 404
-        fail Redminerb::NotFoundError, path
-      else
+      if res.success?
         JSON.parse(res.body)
+      else
+        fail StandardError, "ERROR (status code #{res.status})"
       end
     rescue JSON::ParserError => e
       raise e, "HTTP status code #{res.status}"


### PR DESCRIPTION
# Fix parse responses that not are success

Actualmente cuando la respuesta a la API de Redmine no es 200 o 404, se está intentado parsear la respuesta lo que provoca una excepción durante el parseo:

```
lib/redminerb/client.rb:48:in `rescue in get_json': HTTP status code 403 (JSON::ParserError)
```

Con este cambio se pretende parsear la respuesta de la API únicamente cuando fue **success**, y en caso contrario se devuelve una excepción y el código de respuesta de la llamada.

Evitamos así parsear respuestas innecesarias y mostrar un mensaje de error mas claro de lo que sucede.
# Add fixed_version_id option in issues command

Añade al comando que lista las issues de un proyecto la opción de filtrar por **versión prevista** gracias a la parametro `fixed_version_id`. Filtrar las issues por el "sprint" al q pertenecen, es algo muy común en el día a día, por eso me pareció útil incluir esta opción de filtrado.
