### PR TITLE
Do not raise to user 422 errors

### DIFF
--- a/lib/redminerb/client.rb
+++ b/lib/redminerb/client.rb
@@ -66,7 +66,11 @@ module Redminerb
         rescue JSON::ParserError
           errors = [res.body]
         end
-        fail UnprocessableEntity, errors.join("\n")
+        puts "Failed to process request. Reason:".red
+        errors.each do  |x|
+          puts " - #{x}".red
+        end
+        exit(1)
       else
         fail StandardError, "ERROR (status code #{res.status})"
       end


### PR DESCRIPTION
422 errors means that the server can not process the request for some
logic reason. The reason or the reasons comes as an "errors" array in
the response. It makes no sense to show a stack trace of the errors
instead of just showing the causes of the 422 error before exit.

This makes the UI behave like this on a failed attempt to create an user

```
Login []: carlos.penas
Password []: carlos.penas
Firstname []: carlos.penas
Lastname []: carlos.penas
Mail []: carlos.penas
Is everything OK? (NO/yes) yes
Failed to process request. Reason:
 - Email is invalid
 - Login has already been taken
```

Instead of showing an stack trace of the error
